### PR TITLE
Vehicle Camera Fixes

### DIFF
--- a/RealismClient/FpsCamera.lua
+++ b/RealismClient/FpsCamera.lua
@@ -209,7 +209,7 @@ function FpsCamera:MountTransparency(Transparency)
 	if Transparency.IsValidPartToModify then
 		Transparency.IsValidPartToModify = self.IsValidPartToModify
 		Transparency.HeadAttachments = self.HeadAttachments
-		Transparency.ForceRefresh = true		
+		Transparency.ForceRefresh = true
 	else
 		self:Warn("MountTransparency - Could not find Transparency:IsValidPartToModify(part)!")
 	end


### PR DESCRIPTION
This PR attempts to address issues with Character Realism and the new VehicleCamera camera mode in two ways.

Firstly, I removed the hacky head attachment detection. It is replaced with an overload for TransparencyController:SetupTransparency(character). This fixes the camera module being blocked by the overloaded TransparencyController:IsValidPartToModify(part) method. Without this, there is two seconds of delay before the camera module correctly switches upon exiting the vehicle, along with errors from the VehicleCamera module as the subject is no longer a VehicleSeat.

Secondly, I corrected undesirable behavior when entering a vehicle in first person. Currently, FpsCamera is not capable of detecting that the Humanoid is sitting in a VehicleSeat.  If it doesn't unbind from RenderStep, an undesirable camera offset above the car is present in first person. This is corrected by the new check in RenderStep bound function where the subject has its SeatPart evaluated.